### PR TITLE
Change the name of the MQTT client

### DIFF
--- a/esp-moisture-sensor/esp-moisture-sensor.ino
+++ b/esp-moisture-sensor/esp-moisture-sensor.ino
@@ -73,7 +73,7 @@ void reconnect() {
   reconnect_counter = 0;
   while (!client.connected()) {
     LOG("Attempting MQTT connection...");
-    if (client.connect("ESP8266Client")) {
+    if (client.connect("ESP8266Client_moisture")) {
       LOG("connected", true);
     } else {
       reconnect_counter++;


### PR DESCRIPTION
When I ran both esp-gardener and esp-moisture-sensor, the MQTT broker had issues, because both clients had the same name.